### PR TITLE
Fixes and improvements to the videoplayerlib

### DIFF
--- a/ChromiumBasedEditors/videoplayerlib/qascvideoview.h
+++ b/ChromiumBasedEditors/videoplayerlib/qascvideoview.h
@@ -80,7 +80,7 @@ public:
 	void UpdateFullscreenIcon();
 
 signals:
-	void OnTitleChanged(const QString& sTitle);
+	void titleChanged(const QString& sTitle);
 
 public slots:
 	void slotPlayPause();

--- a/ChromiumBasedEditors/videoplayerlib/src/qascvideoview.cpp
+++ b/ChromiumBasedEditors/videoplayerlib/src/qascvideoview.cpp
@@ -571,7 +571,7 @@ void QAscVideoView::slotOpenFile(QString sFile)
 
 	std::wstring sFileW = sFile.toStdWString();
 	std::wstring sFileName = NSFile::GetFileName(sFileW);
-	emit OnTitleChanged(QString::fromStdWString(sFileName));
+	emit titleChanged(QString::fromStdWString(sFileName));
 }
 
 void QAscVideoView::slotPlayerPosChanged(int nPos)

--- a/ChromiumBasedEditors/videoplayerlib/src/qascvideowidget.cpp
+++ b/ChromiumBasedEditors/videoplayerlib/src/qascvideowidget.cpp
@@ -83,7 +83,7 @@ QAscVideoWidget::QAscVideoWidget(QWidget *parent)
 	m_pVlcPlayer->integrateIntoWidget(this);
 
 	QObject::connect(m_pVlcPlayer, SIGNAL(stateChanged(int)), this, SLOT(slotVlcStateChanged(int)));
-	QObject::connect(m_pVlcPlayer, SIGNAL(timeChanged(qint64)), this, SLOT(slotVlcTimeChanged(qint64)));
+	QObject::connect(m_pVlcPlayer, SIGNAL(positionChanged(float)), this, SLOT(slotVlcPositionChanged(float)));
 
 	m_pMedia = nullptr;
 #endif
@@ -193,9 +193,7 @@ void QAscVideoWidget::setSeek(int nPos)
 	double dProgress = (double)nPos / 100000.0;
 	m_pEngine->setPosition((qint64)(dProgress * nDuration));
 #else
-	libvlc_time_t nDuration = m_pMedia ? m_pMedia->duration() : 0;
-	double dProgress = (double)nPos / 100000.0;
-	m_pVlcPlayer->setTime((int)(dProgress * nDuration));
+	m_pVlcPlayer->setPosition(static_cast<float>(nPos) / 100000);
 #endif
 }
 
@@ -321,11 +319,9 @@ void QAscVideoWidget::slotVlcStateChanged(int state)
 	emit stateChanged((QMediaPlayer_State)stateQ);
 }
 
-void QAscVideoWidget::slotVlcTimeChanged(qint64 time)
+void QAscVideoWidget::slotVlcPositionChanged(float position)
 {
-	libvlc_time_t nDuration = m_pMedia->duration();
-	double dProgress = (double)time / nDuration;
-	emit posChanged((int)(100000 * dProgress + 0.5));
+	emit posChanged(static_cast<int>(100000 * position + 0.5));
 }
 #else
 

--- a/ChromiumBasedEditors/videoplayerlib/src/qascvideowidget.cpp
+++ b/ChromiumBasedEditors/videoplayerlib/src/qascvideowidget.cpp
@@ -207,7 +207,7 @@ void QAscVideoWidget::open(QString& sFile)
 	m_pEngine->play();
 #else
 
-	if (!m_pMedia && !sFile.isEmpty())
+	if (m_pMedia && !sFile.isEmpty())
 	{
 		delete m_pMedia;
 		m_pMedia = nullptr;

--- a/ChromiumBasedEditors/videoplayerlib/src/qascvideowidget.h
+++ b/ChromiumBasedEditors/videoplayerlib/src/qascvideowidget.h
@@ -103,7 +103,7 @@ signals:
 public slots:
 #ifdef USE_VLC_LIBRARY
 	void slotVlcStateChanged(int state);
-	void slotVlcTimeChanged(qint64 time);
+	void slotVlcPositionChanged(float position);
 #else
 	void slotChangeState(QMediaPlayer::State state);
 	void slotPositionChange(qint64 pos);


### PR DESCRIPTION
+ Fixed memory leak
+ Renaming: `signal QAscVideoView::OnTitleChanged` --> `signal QAscVideoView::titleChanged`
+ Use `signal CVlcPlayer::positionChanged` instead of `signal CVlcPlayer::timeChanged` to fix slider bug and simplify the code